### PR TITLE
Update versions of BT libraries and drop support for Foxy

### DIFF
--- a/.github/workflows/clang_format.yml
+++ b/.github/workflows/clang_format.yml
@@ -10,14 +10,13 @@ on:
 
 jobs:
   clang_format:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-
       - name: Run clang format
         run: |
-          sudo apt update
-          sudo apt install -y git clang-format
+          sudo apt update -y -qq
+          sudo apt install -y -qq git clang-format
           if [ $? -ge 1 ]; then return 1; fi
           ./.run-clang-format
           if [ $? -ge 1 ]; then return 1; fi

--- a/.github/workflows/cmake_format.yml
+++ b/.github/workflows/cmake_format.yml
@@ -10,13 +10,13 @@ on:
 
 jobs:
   cmake_format:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v1
-
+      - uses: actions/checkout@v4
       - name: Run CMake Lang Format Check
         run: |
-          sudo pip3 install cmakelang
+          pip3 install cmakelang
+          git init
           ./.run-cmake-format
           output=$(git diff)
           if [ -n "$output" ]; then exit 1; else exit 0; fi

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -33,7 +33,7 @@ jobs:
           path: target_ws/src
 
       - name: Build and Tests
-        uses: tesseract-robotics/colcon-action@v9
+        uses: tesseract-robotics/colcon-action@v13
         with:
           before-script: source /opt/ros/${{ matrix.distro }}/setup.bash
           ccache-prefix: ${{ matrix.distro }}

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: [foxy, humble, jazzy]
+        distro: [humble, jazzy]
     container:
       image: ros:${{ matrix.distro }}
       env:

--- a/dependencies.repos
+++ b/dependencies.repos
@@ -1,11 +1,11 @@
 - git:
     local-name: BehaviorTree.CPP
     uri: https://github.com/BehaviorTree/BehaviorTree.CPP.git
-    version: 4.4.3
+    version: 4.7.2
 - git:
     local-name: BehaviorTree.ROS2
-    uri: https://github.com/marip8/BehaviorTree.ROS2.git
-    version: fd9e565591b019fc55d579577737d7879a88a4a0
+    uri: https://github.com/BehaviorTree/BehaviorTree.ROS2.git
+    version: 7a6ace6424adaa81737b95d20d81e1e8c0782ed7
 - git:
     local-name: motoros2_interfaces
     uri: https://github.com/Yaskawa-Global/motoros2_interfaces.git

--- a/include/motoros2_behavior_tree/motoros2_bt_nodes.h
+++ b/include/motoros2_behavior_tree/motoros2_bt_nodes.h
@@ -22,7 +22,7 @@ public:
   inline BT::NodeStatus onFailure(BT::ServiceNodeErrorCode error) override
   {
     std::stringstream ss;
-    ss << "Service '" << BT::RosServiceNode<T>::prev_service_name_ << "'";
+    ss << "Service '" << BT::RosServiceNode<T>::service_name_ << "'";
 
     switch (error)
     {

--- a/src/motoros2_bt_nodes.cpp
+++ b/src/motoros2_bt_nodes.cpp
@@ -109,7 +109,7 @@ BT::NodeStatus AddJointsToTrajectoryNode::onTick(const typename sensor_msgs::msg
 
     // Get the controller joint names from parameter
     std::vector<std::string> controller_joint_names =
-        get_parameter<std::vector<std::string>>(node_, CONTROLLER_JOINT_NAMES_PARAM);
+        get_parameter<std::vector<std::string>>(node_.lock(), CONTROLLER_JOINT_NAMES_PARAM);
 
     // Find the index of each controller joint in the current trajectory; substitute with -1 if the joint is not found
     std::vector<int> joint_idx_in_trajectory;
@@ -205,9 +205,9 @@ BTCPP_EXPORT void BT_RegisterRosNodeFromPlugin(BT::BehaviorTreeFactory& factory,
   factory.registerNodeType<motoros2_behavior_tree::WriteSingleIONode>("WriteSingleIO", params);
   factory.registerNodeType<motoros2_behavior_tree::ReadSingleIONode>("ReadSingleIO", params);
 
-  if (!params.nh->has_parameter(motoros2_behavior_tree::AddJointsToTrajectoryNode::CONTROLLER_JOINT_NAMES_PARAM))
+  if (!params.nh.lock()->has_parameter(motoros2_behavior_tree::AddJointsToTrajectoryNode::CONTROLLER_JOINT_NAMES_PARAM))
   {
-    params.nh->declare_parameter<std::vector<std::string>>(
+    params.nh.lock()->declare_parameter<std::vector<std::string>>(
         motoros2_behavior_tree::AddJointsToTrajectoryNode::CONTROLLER_JOINT_NAMES_PARAM, {});
   }
   factory.registerNodeType<motoros2_behavior_tree::AddJointsToTrajectoryNode>("AddJointsToTrajectory", params);


### PR DESCRIPTION
This PR updates to later versions of the behavior tree core and ROS2 libraries. Doing so also requires dropping support for ROS2 Foxy, which is now EOL